### PR TITLE
feat: 태그를 클릭하면  velog의 tags페이지로 이동하도록 설정

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -40,16 +40,22 @@ export class App implements IApp {
     return `https://velog.io/@${post.user.username}/${post.url_slug}`;
   }
 
+  private makeTagUrl(tag: string) {
+    return `<a href="https://velog.io/tags/${tag
+      .split(" ")
+      .join("-")}">#${tag}</a>`;
+  }
+
   private async getFeed(): Promise<TrendFeed> {
     const res = await this.fetchData();
     return res.data;
   }
 
   private makeMessage(post: Post) {
-    const tags = post.tags.map((t) => `#${t}`).join(" ");
-    return `<b>${post.title}</b>\n❤️ ${
-      post.likes
-    }\n${tags}\n\n🔗 ${this.makePostUrl(post)}`;
+    const tags = post.tags.map(this.makeTagUrl).join(" ");
+    return `<b>${post.title}</b>\n❤️ ${post.likes}\n🔗 ${this.makePostUrl(
+      post
+    )}\n\n${tags}`;
   }
 
   private makeMessageRequest(post: Post) {

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -49,7 +49,7 @@ Deno.test("make message", async () => {
   const trendFeed: TrendFeed = JSON.parse(await loadFixture("data.json")).data;
   const firstNode = trendFeed.trendingPosts[0];
   const msg = app["makeMessage"](firstNode);
-
+  const makeTagUrl = app["makeTagUrl"];
   assertStringIncludes(msg, firstNode.title, "Expected has title in message");
   assertStringIncludes(msg, firstNode.url_slug, "Expected has url in message");
   assertStringIncludes(
@@ -59,7 +59,7 @@ Deno.test("make message", async () => {
   );
   assertStringIncludes(
     msg,
-    firstNode.tags.map((t) => `#${t}`).join(" "),
+    firstNode.tags.map(makeTagUrl).join(" "),
     "Expected has tags in message"
   );
 });


### PR DESCRIPTION
**참고**
`src/app.ts`에서 tag목록과 url순서를 바꾼 이유는 telegram url preview가 첫 번째 나오는 url을 보여주기 때문입니다.
![image](https://user-images.githubusercontent.com/13795765/119433930-258e9000-bd52-11eb-9e80-f7eef2c0c00f.png)
기존에는 tag가 별도의 웹 사이트로 링크되어 있지 않아, 아티클 주소의 preview를 보여 줍니다.
![image](https://user-images.githubusercontent.com/13795765/119433916-1f001880-bd52-11eb-8b89-0e7d6e177e6d.png)
tag가 별도의 웹 사이트로 링크되어 있고, 이것들이 첫 번째로 등장한 url이 되어서 preview를 이상하게 만듭니다. 따라서, 이번 PR에는 tag목록을 url뒤에 넣었습니다.